### PR TITLE
Add action execution

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -1,6 +1,7 @@
-package env
+package repository
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -8,7 +9,17 @@ import (
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	_ "github.com/mattn/go-sqlite3"
+	gocrud "github.com/tender-barbarian/go-crud"
 )
+
+type GenericRepo[M gocrud.Model] interface {
+	Create(ctx context.Context, model M) (int, error)
+	Get(ctx context.Context, id int) (M, error)
+	GetAll(ctx context.Context) ([]M, error)
+	Delete(ctx context.Context, id int) error
+	Update(ctx context.Context, model M, id int) error
+	GetTable() string
+}
 
 func NewDBConnection(dbPath, migrationsPath string) (*sql.DB, error) {
 	db, err := sql.Open("sqlite3", dbPath)

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+type ErrorHandler struct {
+	logger *slog.Logger
+}
+
+func NewErrorHandler(logger *slog.Logger) *ErrorHandler {
+	return &ErrorHandler{
+		logger: logger,
+	}
+}
+
+func (e *ErrorHandler) WriteError(w http.ResponseWriter, r *http.Request, err error, msg string, statusCode int) {
+	if err == nil {
+		e.logger.Error(msg, "method", r.Method, "uri", r.URL.RequestURI())
+	} else {
+		e.logger.Error(err.Error(), "method", r.Method, "uri", r.URL.RequestURI())
+	}
+
+	http.Error(w, msg, statusCode)
+}

--- a/server/handlers/error_test.go
+++ b/server/handlers/error_test.go
@@ -13,12 +13,12 @@ import (
 
 func TestWriteError(t *testing.T) {
     logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-    h := NewHandlers(logger)
+    errorHandler := NewErrorHandler(logger)
 
     rec := httptest.NewRecorder()
     req := httptest.NewRequest("GET", "/test", nil)
 
-    h.WriteError(rec, req, errors.New("internal"), "bad request", http.StatusBadRequest)
+    errorHandler.WriteError(rec, req, errors.New("internal"), "bad request", http.StatusBadRequest)
 
     assert.Equal(t, http.StatusBadRequest, rec.Code)
     assert.Contains(t, rec.Body.String(), "bad request")

--- a/server/handlers/execute.go
+++ b/server/handlers/execute.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type ExecuteReqBody struct {
+	DeviceId *int `json:"deviceId"`
+	ActionId *int `json:"actionId"`
+}
+
+func (h *Handlers[M, N]) Execute(w http.ResponseWriter, r *http.Request) {
+    var e ExecuteReqBody
+    err := json.NewDecoder(r.Body).Decode(&e)
+    if err != nil {
+        h.errorHandler.WriteError(w, r, err, "invalid JSON body", http.StatusBadRequest)
+		return
+    }
+
+	if e.DeviceId == nil || e.ActionId == nil {
+		h.errorHandler.WriteError(w, r, nil, "invalid params", http.StatusBadRequest)
+		return
+	}
+
+    err = h.service.Execute(r.Context(), *e.DeviceId, *e.ActionId)
+	if err != nil {
+        h.errorHandler.WriteError(w, r, err, "job failed to execute", http.StatusInternalServerError)
+		return
+    }
+}

--- a/server/handlers/execute_test.go
+++ b/server/handlers/execute_test.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tender-barbarian/gniot/repository/models"
+	"github.com/tender-barbarian/gniot/service"
+)
+
+func TestExecute(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := service.NewService[*models.Device, *models.Action](nil, nil)
+	errorHandler := NewErrorHandler(logger)
+	h := NewCustomHandlers(errorHandler, svc)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /execute", h.Execute)
+
+	t.Run("nil body returns 400", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/execute", nil)
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "invalid JSON body")
+	})
+
+	t.Run("empty JSON returns 400", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/execute", strings.NewReader("{}"))
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "invalid params")
+	})
+
+	t.Run("missing deviceId returns 400", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/execute", strings.NewReader(`{"actionId": 1}`))
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "invalid params")
+	})
+
+	t.Run("missing actionId returns 400", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/execute", strings.NewReader(`{"deviceId": 1}`))
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "invalid params")
+	})
+
+	t.Run("wrong type returns 400", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/execute", strings.NewReader(`{"deviceId": "abc"}`))
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "invalid JSON body")
+	})
+}

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -1,22 +1,18 @@
 package handlers
 
 import (
-	"log/slog"
-	"net/http"
+	"github.com/tender-barbarian/gniot/service"
+	gocrud "github.com/tender-barbarian/go-crud"
 )
 
-
-type Handlers struct {
-	logger   *slog.Logger
+type Handlers[M, N gocrud.Model] struct {
+	errorHandler *ErrorHandler
+	service *service.Service[M, N]
 }
 
-func NewHandlers(logger *slog.Logger) *Handlers {
-	return &Handlers {
-		logger:   logger,
+func NewCustomHandlers[M, N gocrud.Model](errorHandler *ErrorHandler, service *service.Service[M, N]) *Handlers[M, N] {
+	return &Handlers[M, N]{
+		errorHandler: errorHandler,
+		service: service,
 	}
-}
-
-func (h *Handlers) WriteError(w http.ResponseWriter, r *http.Request, err error, msg string, statusCode int) {
-	h.logger.Error(err.Error(), "method", r.Method, "uri", r.URL.RequestURI())
-	http.Error(w, msg, statusCode)
 }

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -5,29 +5,22 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/tender-barbarian/gniot/repository"
 	"github.com/tender-barbarian/gniot/server/handlers"
 	gocrud "github.com/tender-barbarian/go-crud"
 )
 
-type genericRepo[M gocrud.Model] interface {
-	Create(ctx context.Context, model M) (int, error)
-	Get(ctx context.Context, id int) (M, error)
-	GetAll(ctx context.Context) ([]M, error)
-	Delete(ctx context.Context, id int) error
-	Update(ctx context.Context, model M, id int) error
-	GetTable() string
-}
-
-func RegisterGenericRoutes[M gocrud.Model](ctx context.Context, repo genericRepo[M], mux *http.ServeMux, handlers *handlers.Handlers) *http.ServeMux {
-	gocrud.RegisterCreate(fmt.Sprintf("POST /%s", repo.GetTable()), mux, repo.Create, handlers)
-	gocrud.RegisterGet(fmt.Sprintf("GET /%s/{id}", repo.GetTable()), mux, repo.Get, handlers)
-	gocrud.RegisterGetAll(fmt.Sprintf("GET /%s", repo.GetTable()), mux, repo.GetAll, handlers)
-	gocrud.RegisterDelete(fmt.Sprintf("DELETE /%s/{id}", repo.GetTable()), mux, repo.Delete, handlers)
-	gocrud.RegisterUpdate(fmt.Sprintf("POST /%s/{id}", repo.GetTable()), mux, repo.Update, handlers)
+func RegisterGenericRoutes[M gocrud.Model](ctx context.Context, repo repository.GenericRepo[M], mux *http.ServeMux, h *handlers.ErrorHandler) *http.ServeMux {
+	gocrud.RegisterCreate(fmt.Sprintf("POST /%s", repo.GetTable()), mux, repo.Create, h)
+	gocrud.RegisterGet(fmt.Sprintf("GET /%s/{id}", repo.GetTable()), mux, repo.Get, h)
+	gocrud.RegisterGetAll(fmt.Sprintf("GET /%s", repo.GetTable()), mux, repo.GetAll, h)
+	gocrud.RegisterDelete(fmt.Sprintf("DELETE /%s/{id}", repo.GetTable()), mux, repo.Delete, h)
+	gocrud.RegisterUpdate(fmt.Sprintf("POST /%s/{id}", repo.GetTable()), mux, repo.Update, h)
 
 	return mux
 }
 
-func RegisterCustomRoutes(mux *http.ServeMux, h *handlers.Handlers) *http.ServeMux {
+func RegisterCustomRoutes[M, N gocrud.Model](mux *http.ServeMux, h *handlers.Handlers[M, N]) *http.ServeMux {
+	mux.HandleFunc("POST /execute", h.Execute)
 	return mux
 }

--- a/service/execute.go
+++ b/service/execute.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+
+	"github.com/tender-barbarian/gniot/repository/models"
+)
+
+func (s *Service[M, N]) Execute(ctx context.Context, deviceId, actionId int) error {
+	d, err := s.devicesRepo.Get(ctx, deviceId)
+	if err != nil {
+		return fmt.Errorf("getting device: %w", err)
+	}
+
+	device, ok := any(d).(*models.Device)
+	if !ok {
+		return errors.New("asserting device type")
+	}
+
+	a, err := s.actionsRepo.Get(ctx, actionId)
+	if err != nil {
+		return fmt.Errorf("getting action: %w", err)
+	}
+
+	action, ok := any(a).(*models.Action)
+	if !ok {
+		return errors.New("asserting action type")
+	}
+
+	var actionIds []int
+	err = json.Unmarshal([]byte(device.Actions), &actionIds)
+	if err != nil {
+		return fmt.Errorf("unmarshalling device actions: %w", err)
+	}
+
+	if !slices.Contains(actionIds, actionId) {
+		return fmt.Errorf("action %d does not belong to device %d", actionId, deviceId)
+	}
+
+	if !isPrivateIP(device.IP) {
+		return errors.New("device IP must be in private range")
+	}
+
+	return s.callJSONRPC(ctx, device.IP, action.Path, action.Params)
+}
+
+func isPrivateIP(ipStr string) bool {
+	host, _, err := net.SplitHostPort(ipStr)
+	if err != nil {
+		host = ipStr
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+
+    if ip.IsPrivate() || ip.IsLoopback() {
+        return true
+    }
+
+    return false
+}

--- a/service/execute_test.go
+++ b/service/execute_test.go
@@ -1,0 +1,209 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tender-barbarian/gniot/repository/models"
+)
+
+type mockDeviceRepo struct {
+	device *models.Device
+	err    error
+}
+
+func (m *mockDeviceRepo) Create(ctx context.Context, model *models.Device) (int, error) {
+	return 0, nil
+}
+func (m *mockDeviceRepo) Get(ctx context.Context, id int) (*models.Device, error) {
+	return m.device, m.err
+}
+func (m *mockDeviceRepo) GetAll(ctx context.Context) ([]*models.Device, error) {
+	return nil, nil
+}
+func (m *mockDeviceRepo) Delete(ctx context.Context, id int) error {
+	return nil
+}
+func (m *mockDeviceRepo) Update(ctx context.Context, model *models.Device, id int) error {
+	return nil
+}
+func (m *mockDeviceRepo) GetTable() string {
+	return "devices"
+}
+
+type mockActionRepo struct {
+	action *models.Action
+	err    error
+}
+
+func (m *mockActionRepo) Create(ctx context.Context, model *models.Action) (int, error) {
+	return 0, nil
+}
+func (m *mockActionRepo) Get(ctx context.Context, id int) (*models.Action, error) {
+	return m.action, m.err
+}
+func (m *mockActionRepo) GetAll(ctx context.Context) ([]*models.Action, error) {
+	return nil, nil
+}
+func (m *mockActionRepo) Delete(ctx context.Context, id int) error {
+	return nil
+}
+func (m *mockActionRepo) Update(ctx context.Context, model *models.Action, id int) error {
+	return nil
+}
+func (m *mockActionRepo) GetTable() string {
+	return "actions"
+}
+
+func TestExecute(t *testing.T) {
+	ctx := context.Background()
+	t.Run("device not found", func(t *testing.T) {
+		deviceRepo := &mockDeviceRepo{err: errors.New("not found")}
+		actionRepo := &mockActionRepo{}
+		service := NewService(deviceRepo, actionRepo)
+
+		err := service.Execute(ctx, 1, 1)
+
+		assert.EqualError(t, err, "getting device: not found")
+	})
+
+	t.Run("action not found", func(t *testing.T) {
+		deviceRepo := &mockDeviceRepo{device: &models.Device{ID: 1, Actions: "[1]"}}
+		actionRepo := &mockActionRepo{err: errors.New("not found")}
+		service := NewService(deviceRepo, actionRepo)
+
+		err := service.Execute(ctx, 1, 1)
+
+		assert.EqualError(t, err, "getting action: not found")
+	})
+
+	t.Run("invalid device actions JSON", func(t *testing.T) {
+		deviceRepo := &mockDeviceRepo{device: &models.Device{ID: 1, Actions: "invalid"}}
+		actionRepo := &mockActionRepo{action: &models.Action{ID: 1}}
+		service := NewService(deviceRepo, actionRepo)
+
+		err := service.Execute(ctx, 1, 1)
+
+		assert.EqualError(t, err, "unmarshalling device actions: invalid character 'i' looking for beginning of value")
+	})
+
+	t.Run("action does not belong to device", func(t *testing.T) {
+		deviceRepo := &mockDeviceRepo{device: &models.Device{ID: 1, Actions: "[2,3]"}}
+		actionRepo := &mockActionRepo{action: &models.Action{ID: 1}}
+		service := NewService(deviceRepo, actionRepo)
+
+		err := service.Execute(ctx, 1, 1)
+
+		assert.EqualError(t, err, "action 1 does not belong to device 1")
+	})
+
+	t.Run("successful execution", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/rpc", r.URL.Path)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			var req JSONRPCRequest
+			err := json.NewDecoder(r.Body).Decode(&req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, "2.0", req.JSONRPC)
+			assert.Equal(t, "toggle", req.Method)
+			assert.Equal(t, map[string]interface{}{"pin": float64(5)}, req.Params)
+
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ip := server.Listener.Addr().String()
+		deviceRepo := &mockDeviceRepo{device: &models.Device{ID: 1, IP: ip, Actions: "[1,2]"}}
+		actionRepo := &mockActionRepo{action: &models.Action{ID: 1, Path: "toggle", Params: `{"pin":5}`}}
+		service := NewService(deviceRepo, actionRepo)
+
+		err := service.Execute(ctx, 1, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("successful execution with empty params", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var req JSONRPCRequest
+			err := json.NewDecoder(r.Body).Decode(&req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Nil(t, req.Params)
+
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ip := server.Listener.Addr().String()
+		deviceRepo := &mockDeviceRepo{device: &models.Device{ID: 1, IP: ip, Actions: "[1]"}}
+		actionRepo := &mockActionRepo{action: &models.Action{ID: 1, Path: "status", Params: ""}}
+		service := NewService(deviceRepo, actionRepo)
+
+		err := service.Execute(ctx, 1, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("device returns non-200 status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		ip := server.Listener.Addr().String()
+		deviceRepo := &mockDeviceRepo{device: &models.Device{ID: 1, IP: ip, Actions: "[1]"}}
+		actionRepo := &mockActionRepo{action: &models.Action{ID: 1, Path: "toggle", Params: `{}`}}
+		service := NewService(deviceRepo, actionRepo)
+
+		err := service.Execute(ctx, 1, 1)
+
+		assert.EqualError(t, err, "device returned status 500")
+	})
+
+	t.Run("device unreachable", func(t *testing.T) {
+		deviceRepo := &mockDeviceRepo{device: &models.Device{ID: 1, IP: "127.0.0.1:99999", Actions: "[1]"}}
+		actionRepo := &mockActionRepo{action: &models.Action{ID: 1, Path: "toggle", Params: `{}`}}
+		service := NewService(deviceRepo, actionRepo)
+
+		err := service.Execute(ctx, 1, 1)
+
+		assert.ErrorContains(t, err, "calling device")
+	})
+
+	t.Run("invalid action params JSON", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ip := server.Listener.Addr().String()
+		deviceRepo := &mockDeviceRepo{device: &models.Device{ID: 1, IP: ip, Actions: "[1]"}}
+		actionRepo := &mockActionRepo{action: &models.Action{ID: 1, Path: "toggle", Params: "invalid json"}}
+		service := NewService(deviceRepo, actionRepo)
+
+		err := service.Execute(ctx, 1, 1)
+
+		assert.EqualError(t, err, "parsing action params: invalid character 'i' looking for beginning of value")
+	})
+
+	t.Run("public IP rejected", func(t *testing.T) {
+		deviceRepo := &mockDeviceRepo{device: &models.Device{ID: 1, IP: "8.8.8.8:80", Actions: "[1]"}}
+		actionRepo := &mockActionRepo{action: &models.Action{ID: 1, Path: "toggle", Params: `{}`}}
+		service := NewService(deviceRepo, actionRepo)
+
+		err := service.Execute(ctx, 1, 1)
+
+		assert.EqualError(t, err, "device IP must be in private range")
+	})
+}

--- a/service/rpc.go
+++ b/service/rpc.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// JSONRPCRequest represents a JSON-RPC 2.0 request
+type JSONRPCRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  any `json:"params,omitempty"`
+	ID      int         `json:"id"`
+}
+
+func (s *Service[M, N]) callJSONRPC(ctx context.Context, ip, method, params string) error {
+	var paramsObj interface{}
+	if params != "" {
+		if err := json.Unmarshal([]byte(params), &paramsObj); err != nil {
+			return fmt.Errorf("parsing action params: %w", err)
+		}
+	}
+
+	data := JSONRPCRequest{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  paramsObj,
+		ID:      1,
+	}
+
+	body, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshaling JSON-RPC request: %w", err)
+	}
+
+	url := fmt.Sprintf("http://%s/rpc", ip)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("constructing HTTP call: %w", err)
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling device: %w", err)
+	}
+	defer resp.Body.Close() // nolint
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("device returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,18 @@
+package service
+
+import (
+	"github.com/tender-barbarian/gniot/repository"
+	gocrud "github.com/tender-barbarian/go-crud"
+)
+
+type Service[M, N gocrud.Model] struct {
+	devicesRepo repository.GenericRepo[M]
+	actionsRepo repository.GenericRepo[N]
+}
+
+func NewService[M, N gocrud.Model](devicesRepo repository.GenericRepo[M], actionsRepo repository.GenericRepo[N]) *Service[M, N] {
+	return &Service[M, N]{
+		devicesRepo: devicesRepo,
+		actionsRepo: actionsRepo,
+	}
+}


### PR DESCRIPTION
This PR adds a new `execute` endpoint that triggers actions on devices via JSON-RPC.